### PR TITLE
List permission required to access /account/transactions

### DIFF
--- a/APIv2.md
+++ b/APIv2.md
@@ -936,6 +936,8 @@ Response example:
  
 `GET /api/2/account/transactions/{id}` - get transaction by transaction id
   
+Requires the "Payment information" API key permission.
+  
 Parameters: 
     
 | Name | Type | Description |


### PR DESCRIPTION
It's not clear in the API Key security settings that for this endpoint to work, the user must select the "Payment information" API key permission.