### PR TITLE
Please clarify the values for the transaction type

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ Responses:
 | paymentId | String | |
 | hash | String | Transaction hash  |
 | status | String | **pending**, **failed**, **success** |
-| type | String | One of: **payout** - crypto withdraw transaction, **payin** - crypto deposit transaction, **deposit**, **withdraw**, **bankToExchange**, **exchangeToBank** |
+| type | String | One of: **payout** - crypto withdraw transaction, **payin** - crypto airdrop, **deposit** - user-initiated deposit, **withdraw**, **bankToExchange**, **exchangeToBank** |
 | createdAt | Datetime |  |
 | updatedAt | Datetime |  |
 


### PR DESCRIPTION
The [/transactions](https://github.com/hitbtc-com/hitbtc-api#get-transactions-history) endpoint returns a `type` that can have several values. This PR attempts to clarify some of them. Ideally, @hitbtc-com should clarify all of them.

In particular, "**payout** - crypto withdraw transaction" - how is this different from **widthdraw**?